### PR TITLE
add post to wish list + some changes to user model

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import express, { Application, NextFunction, Request, Response } from 'express';
 import cors from 'cors';
 import db from './db/db';
 import postRoutes from './routes/post.routes';
+import wishRoutes from './routes/wish.routes';
 
 const app: Application = express();
 
@@ -17,10 +19,15 @@ app.options(/(.*)/, cors());
 db();
 
 // Set up routes
+// post routes
 app.use('/api/posts', postRoutes);
 
+// wish routes
+app.use('/api/wishes', wishRoutes);
+
 // Basic Error Handling Middleware
-app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  // _next is intentionally unused
   console.error(err.stack);
   res.status(500).json({ error: 'Something went wrong' });
 });

--- a/server/src/controllers/wish.controller.ts
+++ b/server/src/controllers/wish.controller.ts
@@ -1,0 +1,38 @@
+import { NextFunction, Request, Response } from 'express';
+import wishService from '../services/wish.service';
+import { Wish } from '../types/wish.types';
+import Post from '../models/post.model';
+// import { getAuthRequest } from '../utils/commonUtils';
+
+const wishController = {
+  createWish: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      //TODO: authReq
+      const data: Wish = req.body;
+
+      if (!data.post || !data.user) {
+        res.status(400).json({ error: 'Missing post or user' });
+        return;
+      }
+
+      // post can be added to wish list only if it is not closed
+      const postDoc = await Post.findById(data.post);
+      if (!postDoc) {
+        res.status(404).json({ error: 'Post not found.' });
+        return;
+      }
+
+      if (postDoc && postDoc.status === 'closed') {
+        res.status(400).json({ error: 'Post is unavailable.' });
+        return;
+      }
+
+      const wish = await wishService.createWish(data);
+      res.status(201).json(wish);
+    } catch (error) {
+      next(error);
+    }
+  },
+};
+
+export default wishController;

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -25,6 +25,11 @@ const userSchema = new Schema<User>(
       lowercase: true,
       match: /^[^\s@]+@[^\s@]+\.(edu)$/,
     },
+    institution: {
+      type: String,
+      required: true,
+      trim: true,
+    },
     isVerified: {
       type: Boolean,
       default: false,
@@ -32,6 +37,10 @@ const userSchema = new Schema<User>(
     profileImage: {
       type: String,
       // default: add a default profile image link here
+    },
+    bio: {
+      type: String,
+      trim: true,
     },
     sublesseeHistory: [{ type: Schema.Types.ObjectId, ref: 'Post' }], // Where user has been a sublessee
     // Additional stats to add later if necessary

--- a/server/src/routes/wish.routes.ts
+++ b/server/src/routes/wish.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import wishController from '../controllers/wish.controller';
+// import { authenticate } from "../middleware/authMiddleware";
+
+const router = Router();
+
+// TODO: Use auth middleware after jwt token is implemented
+// router.use(authenticate);
+
+// router.post('/create', authMiddleware, wishController.createWish);
+router.post('/create', wishController.createWish);
+
+export default router;

--- a/server/src/services/wish.service.ts
+++ b/server/src/services/wish.service.ts
@@ -1,0 +1,12 @@
+import wishModel from '../models/wish.model';
+import { Wish } from '../types/wish.types';
+
+const wishService = {
+  createWish: async (data: Wish) => {
+    const wish = await wishModel.create({ user: data.user, post: data.post });
+
+    return wish;
+  },
+};
+
+export default wishService;

--- a/server/src/types/user.types.ts
+++ b/server/src/types/user.types.ts
@@ -7,7 +7,9 @@ export interface User extends Base, Timestamps {
   lastName: string;
   passwordHash: string;
   email: string;
+  institution: string;
   isVerified: boolean;
   profileImage: string;
+  bio: string;
   sublesseeHistory: (Types.ObjectId | ObjectId | Post)[];
 }


### PR DESCRIPTION
Fixes #57 

# Description
- Add post to wish list with conditions
  - Post is existing
  - Post is available to be added (not over end date or post is not sublet yet)
- Add institution and bio to user model
- Next task: delete post out of wish list

## How Has This Been Tested?
Test on Postman and MongoDb
Since we do not have "users" collection on db yet, I used Mongodb extension to create new collection and dummy users

## Additional context
- >1 users can added the same post to wishlist
![test - 2 users can add the same post](https://github.com/user-attachments/assets/cdad2c18-da0a-49aa-9c04-8a0e5a9b83f3)

- A user cannot added a post >1 time to their wishlist
 ![test - not add duplicated posts by one user](https://github.com/user-attachments/assets/23a2d139-30be-46bf-acbe-cfa81f32be9b)

- A user cannot added a post with `closed` status to wishlist
![test - post is unavailable](https://github.com/user-attachments/assets/e81c73c1-79dd-42e0-965c-9351d134ff50)

## Note
- Authentication must be added later to allow only logged in user to add post to wishlist (wish is associated with post and user)
